### PR TITLE
So we can use this instead of our gist in fourth wall

### DIFF
--- a/repos/performance-platform.json
+++ b/repos/performance-platform.json
@@ -48,17 +48,17 @@
         "owner": "alphagov"
     },
     {
-        "baseUrl": "https://github.gds/api/v3/names",
+        "baseUrl": "https://github.gds/api/v3/repos",
         "name": "pp-deployment",
         "owner": "gds"
     },
     {
-        "baseUrl": "https://github.gds/api/v3/names",
+        "baseUrl": "https://github.gds/api/v3/repos",
         "name": "google-dev-credentials",
         "owner": "gds"
     },
     {
-        "baseUrl": "https://github.gds/api/v3/names",
+        "baseUrl": "https://github.gds/api/v3/repos",
         "name": "pp-pilotis",
         "owner": "gds"
     },
@@ -71,12 +71,12 @@
         "owner": "alphagov"
     },
     {
-        "baseUrl": "https://github.gds/api/v3/names",
+        "baseUrl": "https://github.gds/api/v3/repos",
         "name": "pp-manual",
         "owner": "gds"
     },
     {
-        "baseUrl": "https://github.gds/api/v3/names",
+        "baseUrl": "https://github.gds/api/v3/repos",
         "name": "pp-sync",
         "owner": "gds"
     },

--- a/repos/performance-platform.json
+++ b/repos/performance-platform.json
@@ -20,15 +20,15 @@
         "owner": "alphagov"
     },
     {
-        "name": "limelight",
-        "owner": "alphagov"
-    },
-    {
         "name": "performanceplatform-admin",
         "owner": "alphagov"
     },
     {
-        "name": "performanceplatform-client",
+        "name": "performanceplatform-client.py",
+        "owner": "alphagov"
+    },
+    {
+        "name": "performanceplatform-client.js",
         "owner": "alphagov"
     },
     {
@@ -37,6 +37,10 @@
     },
     {
         "name": "performanceplatform-documentation",
+        "owner": "alphagov"
+    },
+    {
+        "name": "performanceplatform-big-screen-view",
         "owner": "alphagov"
     },
     {
@@ -67,10 +71,6 @@
         "owner": "alphagov"
     },
     {
-        "name": "backdrop-collector-plugins",
-        "owner": "alphagov"
-    },
-    {
         "baseUrl": "https://github.gds/api/v3/repos",
         "name": "pp-manual",
         "owner": "gds"
@@ -81,27 +81,11 @@
         "owner": "gds"
     },
     {
-        "name": "backdrop-collector",
-        "owner": "alphagov"
-    },
-    {
         "name": "puppet-logstash",
         "owner": "alphagov"
     },
     {
-        "name": "backdrop-ga-collector",
-        "owner": "alphagov"
-    },
-    {
-        "name": "backdrop-ga-realtime-collector",
-        "owner": "alphagov"
-    },
-    {
         "name": "backdrop-google-spreadsheet-collector",
-        "owner": "alphagov"
-    },
-    {
-        "name": "backdrop-pingdom-collector",
         "owner": "alphagov"
     },
     {
@@ -114,18 +98,6 @@
     },
     {
         "name": "performance-platform",
-        "owner": "alphagov"
-    },
-    {
-        "name": "pp-development",
-        "owner": "alphagov"
-    },
-    {
-        "name": "puppet-backdrop",
-        "owner": "alphagov"
-    },
-    {
-        "name": "puppet-google_credentials",
         "owner": "alphagov"
     },
     {

--- a/repos/performance-platform.json
+++ b/repos/performance-platform.json
@@ -4,6 +4,10 @@
         "owner": "alphagov"
     },
     {
+        "name": "pp-deploy-lag-radiator",
+        "owner": "alphagov"
+    },
+    {
         "name": "stagecraft",
         "owner": "alphagov"
     },


### PR DESCRIPTION
This adds the deploy lag radiator repo to it's own list of repos so we
can track changes in fourth wall.
